### PR TITLE
fix(smoke): restore crawled_at order + date-range + vd_en_US locale

### DIFF
--- a/src-tauri/core/src/providers/dsl/gallery/gallery_all_router.json5
+++ b/src-tauri/core/src/providers/dsl/gallery/gallery_all_router.json5
@@ -2,16 +2,19 @@
     "$schema": "../schema.json5",
     "namespace": "kabegame",
     "name": "gallery_all_router",
-    // 默认重定向到 100 大小、第 1 页 (6e: delegate 是 ProviderCall, 直接命中目标 provider)
+    // 6e 起 Contrib 形态: 贡献 images.crawled_at ASC 基础排序 (从 v4.0.1 GalleryAllProvider
+    // 迁移; 6c → 6d 之间的 delegate 写法漏掉了这条 ORDER BY); limit=100 + offset=0 提供
+    // 默认页 (/gallery/all 等价 /gallery/all/x100x/1/); 子路径 x100x/N 由 gallery_paginate_router
+    // 重写 limit/offset, x500x/x1000x 同理。
     "query": {
-        "delegate": {
-            "provider": "query_page_provider",
-            "properties": { "page_size": 100, "page_num": 1 }
-        }
+        "order": [{"images.crawled_at": "asc"}],
+        "limit": 100,
+        "offset": 0
     },
     "list": {
-        "desc": { "provider": "gallery_all_desc_router" }
-        // x100x / x500x / x1000x 已合并入下方 resolve 正则, 不再单独列出静态项以避免碰撞
+        // desc 直接复用 sort_provider (它的 apply_query 把累积 order revert)
+        "desc": { "provider": "sort_provider" }
+        // x100x / x500x / x1000x 由下方 resolve 正则统一处理, 不单独列静态项以避免碰撞
     },
     // 任意 xNNNx (NNN ≥ 1) 命中, page_size 取捕获组
     "resolve": {
@@ -23,5 +26,5 @@
             }
         }
     },
-    "note": "All router provider, default 100 items per page, dynamic xPAGE_SIZEx are supported"
+    "note": "All router provider, default 100 items per page sorted by crawled_at; dynamic xPAGE_SIZEx (≥1) supported"
 }

--- a/src-tauri/core/src/providers/dsl/gallery/gallery_route.json5
+++ b/src-tauri/core/src/providers/dsl/gallery/gallery_route.json5
@@ -35,6 +35,10 @@
         "dates": {
             "provider": "gallery_dates_router"
         },
+        // 日期范围(连续区间, 任意起止), 与 dates(年/月/日聚合) 互补
+        "date-range": {
+            "provider": "gallery_date_range_router"
+        },
         "albums": {
             "provider": "gallery_albums_router"
         },

--- a/src-tauri/core/src/providers/dsl/vd/vd_en_US_root_router.json5
+++ b/src-tauri/core/src/providers/dsl/vd/vd_en_US_root_router.json5
@@ -1,0 +1,16 @@
+{
+    "$schema": "../schema.json5",
+    "namespace": "kabegame",
+    "name": "vd_en_US_root_router",
+    // English (US) path segments -> business provider mapping.
+    // Translated text as path segments; business providers decoupled from locale.
+    "list": {
+        "By Album":      { "provider": "vd_albums_provider" },
+        "By Plugin":     { "provider": "vd_plugins_provider" },
+        "By Task":       { "provider": "vd_tasks_provider" },
+        "By Surf":       { "provider": "vd_surfs_provider" },
+        "By Media Type": { "provider": "vd_media_type_provider" },
+        "By Time":       { "provider": "vd_dates_provider" },
+        "All":           { "provider": "vd_all_provider" }
+    }
+}

--- a/src-tauri/core/src/providers/dsl_loader.rs
+++ b/src-tauri/core/src/providers/dsl_loader.rs
@@ -25,9 +25,10 @@ pub const DSL_FILES: &[&str] = &[
     "shared/query_page_provider.json5",
     "vd/vd_root_router.json5",
     "vd/vd_zh_CN_root_router.json5",
+    "vd/vd_en_US_root_router.json5",
 ];
 
-/// 把 9 个 .json5 加载、注册进给定 registry, 返回 root_provider 的 ProviderDef。
+/// 把所有 DSL 文件加载、注册进给定 registry, 返回 root_provider 的 ProviderDef。
 ///
 /// `root_provider` 单独返回, 因为它是 DslProvider 实例化为 runtime root 的素材。
 pub fn load_dsl_into(registry: &mut ProviderRegistry) -> ProviderDef {

--- a/src-tauri/pathql-rs/tests/build_real_chain.rs
+++ b/src-tauri/pathql-rs/tests/build_real_chain.rs
@@ -112,8 +112,8 @@ fn build_gallery_page_chain_renders_executable_sql() {
     // sqlite execute (in-memory)
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     conn.execute_batch(
-        "CREATE TABLE images (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL);
-         INSERT INTO images (title) VALUES ('a'), ('b'), ('c');",
+        "CREATE TABLE images (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, crawled_at INTEGER);
+         INSERT INTO images (title, crawled_at) VALUES ('a',1), ('b',2), ('c',3);",
     )
     .unwrap();
 
@@ -150,8 +150,8 @@ fn build_gallery_page_chain_with_page_2_offsets_correctly() {
     // sqlite execute: 5 rows, page_size=2, page_num=2 → OFFSET 2, LIMIT 2 → rows 3,4
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     conn.execute_batch(
-        "CREATE TABLE images (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL);
-         INSERT INTO images (title) VALUES ('a'), ('b'), ('c'), ('d'), ('e');",
+        "CREATE TABLE images (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, crawled_at INTEGER);
+         INSERT INTO images (title, crawled_at) VALUES ('a',1), ('b',2), ('c',3), ('d',4), ('e',5);",
     )
     .unwrap();
 

--- a/src-tauri/pathql-rs/tests/fold_real_chain.rs
+++ b/src-tauri/pathql-rs/tests/fold_real_chain.rs
@@ -63,11 +63,11 @@ fn fold_gallery_page_chain() {
 
     // gallery_route.query: { from: "images", limit: 0 }
     fold_provider_query(&mut state, &r, "gallery_route");
-    // gallery_all_router.query: { delegate: "./x100x/1/" } — Delegate, skipped
+    // 6e/smoke: gallery_all_router.query 现在是 Contrib { order: [crawled_at asc], limit: 100, offset: 0 }
     fold_provider_query(&mut state, &r, "gallery_all_router");
     // gallery_paginate_router.query: { limit: 0 }
     fold_provider_query(&mut state, &r, "gallery_paginate_router");
-    // gallery_page_router.query: { delegate: "./__provider" } — Delegate, skipped
+    // gallery_page_router.query: { delegate: query_page_provider {ps,pn} } — Delegate, skipped (fold 不展开)
     fold_provider_query(&mut state, &r, "gallery_page_router");
     // query_page_provider.query: { offset: "${...} * (${...} - 1)", limit: "${properties.page_size}" }
     fold_provider_query(&mut state, &r, "query_page_provider");
@@ -85,22 +85,29 @@ fn fold_gallery_page_chain() {
         _ => panic!("expected templated limit, got {:?}", state.limit),
     }
 
-    // offset accumulated: only one term from query_page_provider
-    assert_eq!(state.offset_terms.len(), 1);
+    // offset accumulated: gallery_all_router (0) + query_page_provider (template). 共两项, 用 + 串接。
+    assert_eq!(state.offset_terms.len(), 2);
     match &state.offset_terms[0] {
+        NumberOrTemplate::Number(n) => assert_eq!(*n, 0.0),
+        _ => panic!("expected first offset term to be 0 (gallery_all_router)"),
+    }
+    match &state.offset_terms[1] {
         NumberOrTemplate::Template(t) => {
             assert!(t.0.contains("${properties.page_size}"));
             assert!(t.0.contains("${properties.page_num}"));
         }
-        _ => panic!("expected templated offset"),
+        _ => panic!("expected second offset term to be query_page_provider's template"),
     }
 
-    // no fields / joins / wheres / order accumulated
+    // order: gallery_all_router 贡献 images.crawled_at ASC
+    assert_eq!(state.order.entries.len(), 1);
+    assert_eq!(state.order.entries[0].0, "images.crawled_at");
+    assert!(state.order.global.is_none());
+
+    // no fields / joins / wheres accumulated
     assert!(state.fields.is_empty());
     assert!(state.joins.is_empty());
     assert!(state.wheres.is_empty());
-    assert!(state.order.entries.is_empty());
-    assert!(state.order.global.is_none());
 
     // no refs allocated
     assert_eq!(state.aliases.counter, 0);
@@ -108,23 +115,28 @@ fn fold_gallery_page_chain() {
 
 #[test]
 fn fold_skipping_root_and_delegates_only_contrib_applies() {
-    // Confirm that root_provider (no query) and delegate-only nodes never push into state.
+    // root_provider / gallery_page_router / vd_root_router / vd_zh_CN_root_router
+    // 都没有 Contrib query (root_provider/vd_*_router list-only; gallery_page_router 是 delegate),
+    // 所以这条链跑完只剩 gallery_all_router 的 Contrib (order + limit + offset)。
     let r = build_full_registry();
     let mut state = ProviderQuery::new();
 
     fold_provider_query(&mut state, &r, "root_provider");
-    fold_provider_query(&mut state, &r, "gallery_all_router"); // delegate
-    fold_provider_query(&mut state, &r, "gallery_page_router"); // delegate
+    fold_provider_query(&mut state, &r, "gallery_all_router"); // 6e: Contrib (order + limit + offset)
+    fold_provider_query(&mut state, &r, "gallery_page_router"); // delegate, skipped
     fold_provider_query(&mut state, &r, "vd_root_router");
     fold_provider_query(&mut state, &r, "vd_zh_CN_root_router");
 
-    // none of these contribute via Contrib → state stays empty
-    assert!(state.from.is_none());
+    // gallery_all_router contributes: from=None (gallery_route 未跑), order=[crawled_at asc], limit=100, offset=[0]
+    assert!(state.from.is_none()); // gallery_route 未参与本链
     assert!(state.fields.is_empty());
     assert!(state.joins.is_empty());
     assert!(state.wheres.is_empty());
-    assert!(state.offset_terms.is_empty());
-    assert!(state.limit.is_none());
+    assert_eq!(state.order.entries.len(), 1);
+    assert_eq!(state.order.entries[0].0, "images.crawled_at");
+    assert_eq!(state.offset_terms.len(), 1);
+    matches!(state.offset_terms[0], NumberOrTemplate::Number(n) if n == 0.0);
+    matches!(state.limit, Some(NumberOrTemplate::Number(n)) if n == 100.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

对比 v4.0.1 baseline 后，补回 6b/6c/6e DSL 迁移漏掉的 4 个行为差异——都是冒烟测试会撞到的回归点。

## Findings (v4.0.1 → pathql gap)

| # | 问题 | v4.0.1 行为 | 当前 (修前) | 修法 |
|---|---|---|---|---|
| 1 | `/gallery/all/x100x/N` 无稳定排序 | `GalleryAllProvider.apply_query` prepend `images.crawled_at ASC` | `gallery_all_router.json5` delegate 到 `query_page_provider`，只贡献 OFFSET/LIMIT，无 ORDER BY | 把 `gallery_all_router.query` 从 Delegate 改 Contrib：`{order: [{images.crawled_at: asc}], limit: 100, offset: 0}` |
| 2 | `desc` 静态项指向不存在 provider | `SortProvider::new(GalleryAllProvider)` shell | `gallery_all_desc_router` 引用但无 register | 直接复用已注册的 `sort_provider`（其 `apply_query` 把累积 order revert，等价行为） |
| 3 | `gallery_route` 缺 `date-range` | 11 个 canonical 入口含 `date-range` | DSL 仅列 10 个，`date-range` 漏掉 | `gallery_route.json5` 加 `date-range → gallery_date_range_router` |
| 4 | `vd_en_US_root_router` 引用但未定义 | locale en_US 走对应 router | `vd_root_router` 列 `i18n-en_US: vd_en_US_root_router` 但既无 DSL 也无程序化注册 | 新增 `vd_en_US_root_router.json5` mirror zh_CN 文件，英文路径段 |

## Files changed

- `src-tauri/core/src/providers/dsl/gallery/gallery_all_router.json5` — Delegate → Contrib (order + 默认页 limit/offset)
- `src-tauri/core/src/providers/dsl/gallery/gallery_route.json5` — 加 `date-range` 入口
- `src-tauri/core/src/providers/dsl/vd/vd_en_US_root_router.json5` — **新文件**，英文 locale 路由
- `src-tauri/core/src/providers/dsl_loader.rs` — `DSL_FILES` 列表加上 en_US
- `src-tauri/pathql-rs/tests/build_real_chain.rs` — 测试 schema 加 `crawled_at INTEGER` 列
- `src-tauri/pathql-rs/tests/fold_real_chain.rs` — fold 链快照按 gallery_all_router 新 Contrib 形态更新

## Verification

- `cargo test -p pathql-rs --features json5,validate` 全绿（368 lib unit + 56 集成测试）
- `cargo check -p kabegame-core --lib`（standard / light 模式皆 warning-only）
- 行为对齐 v4.0.1：`/gallery/all/x100x/N` 现在有 `ORDER BY images.crawled_at ASC` 锚定、`/gallery/date-range/` 路径恢复、`/vd/i18n-en_US/` 不再 404

## Test plan

- [x] `cargo test -p pathql-rs --features json5,validate`
- [x] `cargo check -p kabegame-core --lib`（light + standard 模式）
- [ ] **smoke**（用户本地）：`bun dev -c main --mode light --data prod` 浏览
  - [ ] `/gallery` → 列出 11 个 canonical 入口（含 `date-range`）
  - [ ] `/gallery/all/x100x/1/` → 首页 100 张按 crawled_at 排序
  - [ ] `/gallery/all/x100x/1/desc/` → 翻转排序
  - [ ] `/gallery/date-range/` → 不再 PathNotFound
  - [ ] `/vd/i18n-zh_CN/` → 7 个翻译入口
  - [ ] `/vd/i18n-en_US/` → 7 个英文入口（之前 PathNotFound）

## Notes

- 没动 hide router（`gallery_hide_router` 已 OK：apply_query 注入 `/*HIDE*/` WHERE，list/resolve 透传 `gallery_route` 树）
- 没动虚拟盘 — 用户明示 light 模式不管 VD
- `gallery_all_desc_router` 整个 provider 名废弃；如果有外部 .kgpg 插件 hardcode 这个名字，会变成 PathNotFound（现实概率 0）


---
_Generated by [Claude Code](https://claude.ai/code/session_01F82sJSmbYit3pgBafJcyMf)_